### PR TITLE
builder: tweak broot.mock() call

### DIFF
--- a/plugin/builder/image_builder.py
+++ b/plugin/builder/image_builder.py
@@ -440,9 +440,10 @@ class ImageBuilderBuildArchTask(BaseBuildTask):
         # And execute it. The exception message here might look very terse
         # however all output from the build root is logged and attached as log
         # files to the task.
-        if broot.mock(
+        exit_code = broot.mock(
             ["--cwd", broot.tmpdir(within=True), "--chroot", "--"] + cmd
-        ):
+        )
+        if exit_code != 0:
             raise koji.GenericError("`image-builder` failed")
 
         # We have done our build, now it is time to massage our outputs into


### PR DESCRIPTION
Tiny drive-by to make it more obvious what `broot.mock()` returns.