### PR TITLE
ci: enable epel8 in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,18 +21,21 @@ jobs:
       - fedora-branched  # rawhide updates are created automatically
       - epel-10
       - epel-9
+      - epel-8
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
       - epel-10
       - epel-9
+      - epel-8
   - job: propose_downstream
     trigger: release
     dist_git_branches:
       - fedora-all
       - epel-10
       - epel-9
+      - epel-8
   - job: copr_build
     trigger: pull_request
     targets: &build_targets
@@ -40,6 +43,10 @@ jobs:
       - fedora-all-s390x
       - fedora-all-ppc64le
       - fedora-all
+      - epel-8-aarch64
+      - epel-8-s380x
+      - epel-8-ppc64le
+      - epel-8-x86_64
       - epel-9-aarch64
       - epel-9-s390x
       - epel-9-ppc64le


### PR DESCRIPTION
We'll need to ship this package in epel8 as well as CentOS stream infrastructure runs on 8. Adjust the PackIt config to do so.

I've already done scratch builds and a manual release to epel8 of the latest version but we might want to to a bump after this PR is merged to have PackIt handle the branches.

---

See: https://issues.redhat.com/browse/CS-2797 for the request.