### PR TITLE
build: include `arch` in artifact names

### DIFF
--- a/plugin/builder/image_builder.py
+++ b/plugin/builder/image_builder.py
@@ -444,7 +444,7 @@ class ImageBuilderBuildArchTask(BaseBuildTask):
                 cmd.extend(["--ostree-parent", ostree_parent])
 
         cmd.extend(["--output-dir", "/builddir/output"])
-        cmd.extend(["--output-name", f"{name}-{version}-{release}"])
+        cmd.extend(["--output-name", f"{name}-{version}-{release}.{arch}"])
 
         # And execute it. The exception message here might look very terse
         # however all output from the build root is logged and attached as log

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -56,7 +56,7 @@ def test_build_arch_task(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw",
         ],
     ]
@@ -104,7 +104,7 @@ def test_build_arch_task_with_repos(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw",
         ],
     ]
@@ -150,7 +150,7 @@ def test_build_arch_task_multiple_types(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw",
         ],
         [
@@ -171,7 +171,7 @@ def test_build_arch_task_multiple_types(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw-zst",
         ],
     ]
@@ -227,7 +227,7 @@ def test_build_arch_task_ostree(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw",
         ],
     ]


### PR DESCRIPTION
When uploading artifacts to builds it is important that the artifact names are unique. Let's include the architecture so that when a build has multiple we don't try to write the same name multiple times (which fails).