### PR TITLE
builder: return `release` in results

### DIFF
--- a/plugin/builder/image_builder.py
+++ b/plugin/builder/image_builder.py
@@ -482,7 +482,7 @@ class ImageBuilderBuildArchTask(BaseBuildTask):
             "task_id": self.id,
             "name": name,
             "version": version,
-            "release": distro,
+            "release": release,
             "arch": arch,
             "files": [],
             "logs": [],

--- a/run.py
+++ b/run.py
@@ -388,7 +388,7 @@ def build(path):
                     "fedora-42",
                     "Fedora-Minimal",
                     "42",
-                    "minimal-raw",
+                    "minimal-raw-xz",
                 ]
             ),
             check=True,

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -301,7 +301,7 @@ def test_build_arch_task_seed(koji_mock_kojid):
             "--output-dir",
             "/builddir/output",
             "--output-name",
-            "Fedora-Minimal-42-1",
+            "Fedora-Minimal-42-1.x86_64",
             "minimal-raw",
         ],
     ]


### PR DESCRIPTION
The builder plugin incorrectly returns `distro` instead of `release` for the release field of the results.

Also a minor testcase fix, don't really understand how that happened but likely both PRs were open at the same time.