### PR TITLE
doc: add `index`

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,5 @@
+# koji-image-builder
+
+`koji-image-builder` provides plugins for various parts of the [Koji](https://docs.pagure.org/koji/) build system. These allow administrators and users of a Koji instance to build images with [image-builder](https://github.com/osbuild/image-builder-cli).
+
+For any questions you can take a look at our [GitHub issues](https://github.com/osbuild/koji-image-builder) or [GitHub discussions](https://github.com/orgs/osbuild/discussions). We're also available in the [#image-builder:fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org?web-instance%5Belement.io%5D=chat.fedoraproject.org) Matrix channel.


### PR DESCRIPTION
There's no index file in the doc directory, this *might* be problematic when we generate the website (or not). Regardless, let's include it.