### PR TITLE
many: accept `preview` option (HMS-9969)

### DIFF
--- a/plugin/builder/image_builder.py
+++ b/plugin/builder/image_builder.py
@@ -448,6 +448,12 @@ class ImageBuilderBuildArchTask(BaseBuildTask):
         if seed is not None:
             cmd.extend(["--seed", str(seed)])
 
+        # If the preview state is set, pass it along; requires `image-builder`
+        # >= 49 in the buildroot.
+        preview = opts.get("preview", None)
+        if preview is not None:
+            cmd.extend(["--preview", "true" if preview else "false"])
+
         cmd.extend(["--output-dir", "/builddir/output"])
         cmd.extend(["--output-name", f"{name}-{version}-{release}.{arch}"])
 

--- a/plugin/cli/image_builder.py
+++ b/plugin/cli/image_builder.py
@@ -80,6 +80,24 @@ def handle_image_builder_build(gopts, session, args):
         type=int,
     )
 
+    parser.add_option(
+        "--preview",
+        help="Set preview to true. Overrides distribution default prerelease status.",
+        dest="preview",
+        action="store_true",
+    )
+
+    parser.add_option(
+        "--no-preview",
+        help="Set preview to false. Overrides distribution default prerelease status.",
+        dest="preview",
+        action="store_false",
+    )
+
+    # this way we have 'None' when not passed which gives the default behavior (e.g.
+    # whatever is set on the distro) and true/false otherwise which always override
+    parser.set_defaults(preview=None)
+
     (opts, args) = parser.parse_args(args)
 
     if len(args) < 4:
@@ -125,6 +143,9 @@ def handle_image_builder_build(gopts, session, args):
 
     if opts.seed:
         task_opts["seed"] = opts.seed
+
+    if opts.preview is not None:
+        task_opts["preview"] = opts.preview
 
     if opts.blueprint:
         with open(opts.blueprint, "r") as f:

--- a/plugin/hub/image_builder.py
+++ b/plugin/hub/image_builder.py
@@ -83,6 +83,10 @@ IMAGE_BUILDER_BUILD_SCHEMA = {
                     "type": "integer",
                     "description": "PRNG seed, can be used to predict filesystem UUIDs",
                 },
+                "preview": {
+                    "type": "boolean",
+                    "description": "Override builds prerelease/preview state."
+                }
             },
         },
     },

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -307,3 +307,53 @@ def test_build_arch_task_seed(koji_mock_kojid):
     ]
 
 
+def test_build_arch_task_preview(koji_mock_kojid):
+    import plugin.builder.image_builder as builder
+
+    t = builder.ImageBuilderBuildArchTask()
+
+    t.id = None
+    t.session = None
+    t.options = MockOptions(topurl="/")
+    t.workdir = None
+
+    t.handler(
+        "Fedora-Minimal",
+        "42",
+        "1",
+        "x86_64",
+        ["minimal-raw"],
+        {"build_tag": "f42-build", "build_tag_name": "f42-build"},
+        {"extra": {"mock.new_chroot": 0}},
+        {"id": 1},
+        {
+            "preview": False,
+        },
+    )
+
+    assert koji_mock_kojid.buildroot.mock_calls == [
+        [
+            "--cwd",
+            str(koji_mock_kojid.buildroot._tmpdir),
+            "--chroot",
+            "--",
+            "sh",
+            str(koji_mock_kojid.buildroot._tmpdir) + "/mock-wrap",
+            "image-builder",
+            "-v",
+            "build",
+            "--use-librepo=false",
+            "--force-repo",
+            "//repos/f42-build/1/$arch",
+            "--with-sbom",
+            "--with-manifest",
+            "--preview", "false",
+            "--output-dir",
+            "/builddir/output",
+            "--output-name",
+            "Fedora-Minimal-42-1.x86_64",
+            "minimal-raw",
+        ],
+    ]
+
+


### PR DESCRIPTION
Accept a preview option which maps onto `image-builder`'s `--preview` argument which was introduced in version 49.

This allows users of the koji plugin to override the preview/prerelease status of a distribution that is being built. This will be done by `pungi` when a release-candidate is being built.

Currently we need to quickly update our distribution definitions to change this field during or just before an RC; but the decision should lie with the release engineering team scheduling the builds instead.