### PR TITLE
many: failable arch propagation

### DIFF
--- a/plugin/builder/image_builder.py
+++ b/plugin/builder/image_builder.py
@@ -197,6 +197,9 @@ class ImageBuilderBuildTask(BuildImageTask):
                     arch=arch,
                 )
 
+                if arch in self.opts.get("failable_arches", []):
+                    canfails.append(subtasks[arch])
+
             results = self.wait(
                 list(subtasks.values()),
                 all=True,

--- a/plugin/cli/image_builder.py
+++ b/plugin/cli/image_builder.py
@@ -33,6 +33,13 @@ def handle_image_builder_build(gopts, session, args):
         help="Only build provided architectures",
     )
     parser.add_option(
+        "--failable-arch",
+        action="append",
+        dest="failable_arches",
+        default=[],
+        help="Allow an arch to fail without failing the parent task",
+    )
+    parser.add_option(
         "--repo",
         action="append",
         help="Specify a repo that will override the repo used to install "
@@ -150,6 +157,9 @@ def handle_image_builder_build(gopts, session, args):
     if opts.blueprint:
         with open(opts.blueprint, "r") as f:
             task_opts["blueprint"] = json.load(f)
+
+    if opts.failable_arches:
+        task_opts["failable_arches"] = opts.failable_arches
 
     task_id = session.imageBuilderBuild(
         *task_args,

--- a/plugin/hub/image_builder.py
+++ b/plugin/hub/image_builder.py
@@ -86,6 +86,11 @@ IMAGE_BUILDER_BUILD_SCHEMA = {
                 "preview": {
                     "type": "boolean",
                     "description": "Override builds prerelease/preview state."
+                },
+                "failable_arches": {
+                    "type": "array",
+                    "description": "Architectures allowed to fail",
+                    "items": {"type": "string"},
                 }
             },
         },

--- a/run.py
+++ b/run.py
@@ -390,6 +390,7 @@ def build(path):
                     "Fedora-Minimal",
                     FEDORA_VERSION,
                     "minimal-raw-xz",
+                    "--failable-arch", "x86_64",
                 ]
             ),
             check=True,


### PR DESCRIPTION
We noticed in todays rawhide compose that the failable arches weren't correctly handled in the pungi phase. This led me to realize that we also don't handle the partial failable arches.

Let's allow passing `failable_arches` to the `imageBuilderBuild` task which then uses it to allow a certain subset of tasks to fail.

If all tasks fail then we still fail the parent task. This is the same behavior as other plugins.

---

The initial PR handling full-failure in pungi is here: https://pagure.io/pungi/pull-request/1906, integrating the partial failures will require a follow-up PR in pungi after I've spoken to all relevant releng teams to upgrade their deployment of `koji-image-builder`.